### PR TITLE
Fix $CLICOLOR check for ll

### DIFF
--- a/ls.plugin.zsh
+++ b/ls.plugin.zsh
@@ -69,7 +69,7 @@ else
   compdef la=ls
   
   function ll(){
-    if [[ "$CLICOLOR" = 1 ]]; then
+    if [[ "$CLICOLOR" != "0" ]]; then
       $_grc $_ls ${_ls_params} -l $@
     else
       $_ls -l $@


### PR DESCRIPTION
021fb1e9f539e1bc73e4772b99b86dccb7d2c93a changed the `$CLICOLOR` variable checking condition from `[[ "$CLICOLOR" = 1 ]]` to `[[ "$CLICOLOR" != "0" ]]` for all the functions except `ll`. This fixes that.