### PR TITLE
Add ZSH_LS_PREFER_LS as a config environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Zsh plugin for ls. It improves the output of `ls`, and adds the following aliase
 
 ![screenshot](./ls.png)
 
-This plugin supports [exa](https://github.com/ogham/exa), if installed then:
+This plugin supports [exa](https://github.com/ogham/exa), if installed and no `ZSH_LS_PREFER_LS` is defined as environment variable then:
 
 * `l` - show files, without git ignored
 * `ls` - show files

--- a/ls.plugin.zsh
+++ b/ls.plugin.zsh
@@ -5,7 +5,7 @@
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 local _DIRNAME="${0:h}"
 
-if (( $+commands[exa] )); then
+if (( $+commands[exa] && ! ${+ZSH_LS_PREFER_LS} )); then
   typeset -g exa_params
   # Use exa
   exa_params=('--git' '--icons' '--classify' '--group-directories-first' '--time-style=long-iso' '--group' '--color-scale')


### PR DESCRIPTION
Hello, and thanks for developers and contributors of this interesting plugin!.

This is to enable GNU ls configs even if exa is installed. Currently no easy way to do it because we must uninstall exa or remove directories contains exa from $PATH. But they are bothersome. So add an environment variable to prioritize the configs. It is easy and major way to config plugin.

To enable this, we only need to add a following line to zshrc.

```zsh
ZSH_LS_PREFER_LS=

# Follow plugin loading...
```