### PR TITLE
fix: Enable display of hidden files with exa

### DIFF
--- a/ls.plugin.zsh
+++ b/ls.plugin.zsh
@@ -107,7 +107,11 @@ else
   compdef l=ls
 
   function la() {
-    $_ls ${_ls_params} -C -A $@
+    if [[ "$ZSH_LS_BACKEND" == "exa" ]]; then
+      exa -a ${exa_params} $@
+    else
+      ls -a $@
+    fi
   }
   compdef la=ls
 
@@ -120,4 +124,3 @@ else
   }
   compdef ll=ls
 fi
-


### PR DESCRIPTION
closes #12

Modified the Zsh plugin code to use the `-a` option with the `exa` command,
allowing it to display hidden files correctly. Resolves the issue where
`ls -A` was not working as expected.