### PR TITLE
Add `eza` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Zsh plugin for ls. It improves the output of `ls`, and adds the following aliase
 * `la` - show all files
 * `ll` - show files line by line
 
-This plugin supports [lsd](https://github.com/Peltoche/lsd), [exa](https://github.com/ogham/exa) and [GNU ls](https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html) backends.
+This plugin supports [lsd](https://github.com/Peltoche/lsd), [exa](https://github.com/ogham/exa)/[eza](https://github.com/eza-community/eza) and [GNU ls](https://www.gnu.org/software/coreutils/manual/html_node/ls-invocation.html) backends.
 
 You can change ls backend using `ZSH_LS_BACKEND` variable, set it to `lsd`, `exa` or `ls`.
-If no `ZSH_LS_BACKEND` is defined as environment variable then backend will be selected automatically: `lsd`, or `exa`, or `ls`
+If no `ZSH_LS_BACKEND` is defined as environment variable then backend will be selected automatically: `lsd`, or `eza`/`exa`, or `ls`
 
-> You can disable git integration in exa using this:
+> You can disable git integration in eza/exa using this:
 
 ```sh
 export ZSH_LS_DISABLE_GIT=true

--- a/ls.plugin.zsh
+++ b/ls.plugin.zsh
@@ -16,6 +16,8 @@ if [[ -z "$ZSH_LS_BACKEND" ]]; then
     ZSH_LS_BACKEND='ls'
   elif (( $+commands[lsd] )); then
     ZSH_LS_BACKEND='lsd'
+  elif (( $+commands[eza] )); then
+    ZSH_LS_BACKEND='eza'
   elif (( $+commands[exa] )); then
     ZSH_LS_BACKEND='exa'
   else
@@ -47,7 +49,7 @@ if [[ "$ZSH_LS_BACKEND" == "lsd" ]]; then
     lsd --header --long ${lsd_params} $@
   }
   compdef ll=lsd
-elif [[ "$ZSH_LS_BACKEND" == "exa" ]]; then
+elif [[ "$ZSH_LS_BACKEND" == "exa" || "$ZSH_LS_BACKEND" == "eza" ]]; then
   typeset -g exa_params; exa_params=('--icons' '--classify' '--group-directories-first' '--time-style=long-iso' '--group' '--color=auto')
 
   if ((! ${+ZSH_LS_DISABLE_GIT})); then
@@ -55,24 +57,24 @@ elif [[ "$ZSH_LS_BACKEND" == "exa" ]]; then
   fi
 
   function ls() {
-    exa ${exa_params} $@
+    $ZSH_LS_BACKEND ${exa_params} $@
   }
-  compdef ls=exa
+  compdef ls=$ZSH_LS_BACKEND
 
   function l() {
-    exa --git-ignore ${exa_params} $@
+    $ZSH_LS_BACKEND --git-ignore ${exa_params} $@
   }
-  compdef l=exa
+  compdef l=$ZSH_LS_BACKEND
 
   function la() {
-    exa -a ${exa_params} $@
+    $ZSH_LS_BACKEND -a ${exa_params} $@
   }
-  compdef la=exa
+  compdef la=$ZSH_LS_BACKEND
 
   function ll() {
-    exa --header --long ${exa_params} $@
+    $ZSH_LS_BACKEND --header --long ${exa_params} $@
   }
-  compdef ll=exa
+  compdef ll=$ZSH_LS_BACKEND
 else
   typeset -g _ls
   _ls=(=ls)


### PR DESCRIPTION
@ariasuni over at https://github.com/ogham/exa has updated the repo's README to note that the project is currently unmaintained, and recommends using the maintained fork eza:
https://github.com/eza-community/eza

This commit adds support for `eza` as a backend, preferring it over `exa` if both installed, and softening the configuration to match that of exa until such a time where the options should differ.