### PR TITLE
Fix #20: Remove extra ZSH_LS_BACKEND='ls'

### DIFF
--- a/ls.plugin.zsh
+++ b/ls.plugin.zsh
@@ -23,8 +23,6 @@ if [[ -z "$ZSH_LS_BACKEND" ]]; then
   else
     ZSH_LS_BACKEND='ls'
   fi
-else
-  ZSH_LS_BACKEND='ls'
 fi
 
 if [[ "$ZSH_LS_BACKEND" == "lsd" ]]; then


### PR DESCRIPTION
ZSH_LS_BACKEND is assigned in such a way that it will always result in ZSH_LS_BACKEND='ls' no matter if ZSH_LS_BACKEND is set to something other than 'ls'