### PR TITLE
Fix safe-compdef syntax errors causing startup warnings

### DIFF
--- a/ls.plugin.zsh
+++ b/ls.plugin.zsh
@@ -22,7 +22,7 @@ fi
 # If it exists, it will set the completion definition for the given binary.
 # If it does not exist, it will not set the completion definition and will not throw an error.
 # Usage: safe-compdef <binary> <function>
-# Example: safe-compdef ls=lsd
+# Example: safe-compdef ls lsd
 function safe-compdef() {
   local bin=$1
   local fn=$2
@@ -60,27 +60,27 @@ if [[ "$ZSH_LS_BACKEND" == "lsd" ]]; then
   function ls() {
     lsd ${lsd_params} $@
   }
-  safe-compdef ls=lsd
+  safe-compdef ls lsd
 
   function l() {
     lsd ${lsd_params} $@
   }
-  safe-compdef l=lsd
+  safe-compdef l lsd
 
   function la() {
     lsd -a ${lsd_params} $@
   }
-  safe-compdef la=lsd
+  safe-compdef la lsd
 
   function ll() {
     lsd --header --long ${lsd_params} $@
   }
-  safe-compdef ll=lsd
+  safe-compdef ll lsd
 
   function lt() {
     lsd --tree ${lsd_params} $@
   }
-  safe-compdef lt=lsd
+  safe-compdef lt lsd
 elif [[ "$ZSH_LS_BACKEND" == "exa" || "$ZSH_LS_BACKEND" == "eza" ]]; then
   typeset -g exa_params; exa_params=('--icons' '--classify' '--group-directories-first' '--time-style=long-iso' '--group' '--color=auto')
 
@@ -91,27 +91,27 @@ elif [[ "$ZSH_LS_BACKEND" == "exa" || "$ZSH_LS_BACKEND" == "eza" ]]; then
   function ls() {
     $ZSH_LS_BACKEND ${exa_params} $@
   }
-  safe-compdef ls=$ZSH_LS_BACKEND
+  safe-compdef ls $ZSH_LS_BACKEND
 
   function l() {
     $ZSH_LS_BACKEND --git-ignore ${exa_params} $@
   }
-  safe-compdef l=$ZSH_LS_BACKEND
+  safe-compdef l $ZSH_LS_BACKEND
 
   function la() {
     $ZSH_LS_BACKEND -a ${exa_params} $@
   }
-  safe-compdef la=$ZSH_LS_BACKEND
+  safe-compdef la $ZSH_LS_BACKEND
 
   function ll() {
     $ZSH_LS_BACKEND --header --long ${exa_params} $@
   }
-  safe-compdef ll=$ZSH_LS_BACKEND
+  safe-compdef ll $ZSH_LS_BACKEND
 
   function lt() {
     $ZSH_LS_BACKEND --tree ${exa_params} $@
   }
-  safe-compdef lt=$ZSH_LS_BACKEND
+  safe-compdef lt $ZSH_LS_BACKEND
 else
   typeset -g _ls
   _ls=(=ls)
@@ -138,17 +138,17 @@ else
   function ls() {
     $_ls ${_ls_params} -C $@
   }
-  safe-compdef ls=ls
+  safe-compdef ls ls
 
   function l() {
     $_ls ${_ls_params} -C $@
   }
-  safe-compdef l=ls
+  safe-compdef l ls
 
   function la() {
     $_ls ${_ls_params} -C -A $@
   }
-  safe-compdef la=ls
+  safe-compdef la ls
 
   function ll() {
     if [[ "$CLICOLOR" != "0" ]]; then
@@ -157,7 +157,7 @@ else
       $_ls -l $@
     fi
   }
-  safe-compdef ll=ls
+  safe-compdef ll ls
 
   function lt() {
     tree $@


### PR DESCRIPTION
This PR fixes the syntax used for calling the `safe-compdef` function.

After applying the changes, the error logs below disappear:
```
compdef: unknown command or service: ls=
compdef: unknown command or service: ls=
compdef: unknown command or service: ls=
```